### PR TITLE
Support root element destructions (e.g with if instruction)

### DIFF
--- a/projects/angular-tradingview-widget/src/lib/tradingview-widget.component.ts
+++ b/projects/angular-tradingview-widget/src/lib/tradingview-widget.component.ts
@@ -10,7 +10,7 @@ declare const TradingView: any;
   `,
   styles: []
 })
-export class TradingviewWidgetComponent implements OnInit {
+export class TradingviewWidgetComponent implements AfterViewInit {
 
   private _widgetConfig!: ITradingViewWidget;
   private _defaultConfig: ITradingViewWidget = {
@@ -51,7 +51,7 @@ export class TradingviewWidgetComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit(): void {
+  ngAfterViewInit(): void {
     this.appendScript(this.initWidget.bind(this));
   }
 


### PR DESCRIPTION
When using an instruction that removes root element from dom (see below example), only the first execution works. The next ones stay blank.

This PR fixes it.

```html
<button (click)="show = !show">show/hide</button>

@if(show){
    <tradingview-widget style="height:100%;" [widgetConfig]="config"></tradingview-widget>
}
```